### PR TITLE
DNS TXT Records > 255 incorrectly threw an exception...

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,8 +1,9 @@
 name: dns
-version: 1.0.0
+version: 1.0.1
 
 authors:
   - 636f7374
+  - usiegj00
 
 crystal: ">= 1.0.0"
 license: BSDv3

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: dns
-version: 1.0.1
+version: 1.0.2
 
 authors:
   - 636f7374

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: dns
-version: 1.0.2
+version: 1.0.3
 
 authors:
   - 636f7374

--- a/src/dns/records/txt.cr
+++ b/src/dns/records/txt.cr
@@ -23,7 +23,8 @@ struct DNS::Records
       end
 
       if txt_length != (data_length_buffer.size - 1_i32)
-        raise Exception.new String.build { |io| io << "dataLength or TXTLength is incorrect, or Packet Error!" }
+        puts "Probably not an exception: txt_length=#{txt_length} but data_length_buffer=#{data_length_buffer.size-1_i32}"
+        # raise Exception.new String.build { |io| io << "dataLength or TXTLength is incorrect, or Packet Error!" }
       end
 
       new name: name, classType: class_type, ttl: ttl.seconds, txt: data_length_buffer.gets_to_end

--- a/src/dns/records/txt.cr
+++ b/src/dns/records/txt.cr
@@ -6,6 +6,18 @@ struct DNS::Records
     property txt : String
 
     def initialize(@name : String, @classType : Packet::ClassFlag, @ttl : Time::Span, @txt : String)
+      size = @txt.size
+      if size > 255
+        # Here, @txt includes an invalid character on the 255th byte (due to multiple packet concatenation--see below--so we manually remove.
+        # Apologies on the code--rather iterate on groups of 256 bytes, dropping the last one, but didn't see how to crystal-lang that.
+        buf = ""
+        i = 0
+        while i < size
+          buf += @txt[i..i+254]
+          i += 256
+        end
+        @txt = buf
+      end
     end
 
     def self.from_io(name : String, protocol_type : ProtocolType, io : IO, buffer : IO::Memory, options : Options = Options.new) : TXT


### PR DESCRIPTION
I've just ignored the exception, but not fixed anything underlying. I would guess it's the difference between the size of a particular DNS packet (data_length_buffer.read_byte of 255) vs the concatenated record size (data_length_buffer.size of >255). This came out of a TXT record lookup where the record contents were large enough to split into multiple records. Google has one of these if you want to test it. The large record from ```dig github.com txt``` will now be returned by DNS.cr, but will not prior to this patch.